### PR TITLE
指定したURLのwebページから.pngファイルのURLを取得・出力する

### DIFF
--- a/problem07.rb
+++ b/problem07.rb
@@ -1,0 +1,17 @@
+require "nokogiri"
+require "open-uri"
+require "uri"
+
+# 画像URLを取得するwebページのURLを定義
+base_url = "https://www.kurobe-dam.com/"
+
+# Nokogiriを使って指定したURLのHTMLを取得し、パースした結果をdocに格納
+doc = Nokogiri::HTML(URI.open(base_url))
+
+# ページ内の拡張子が.pngの画像タグを全て取得
+imgs = doc.css('img[src$=".png"]')
+
+# 取得した画像タグそれぞれに対して、URLを生成して出力
+imgs.each do |img|
+    puts URI.join(base_url, img['src'])
+end


### PR DESCRIPTION
## イシュー番号
- open #13

## 関連ドキュメント
[github nokogiri](https://github.com/sparklemotion/nokogiri)
[nokogiri 公式ドキュメント](https://nokogiri.org/index.html)
[RubyDoc URIモジュール](https://docs.ruby-lang.org/ja/latest/class/URI.html#S_JOIN)

## 実装内容
- webページのURLを定義
- Nokogiriを使用して、指定したURLのHTMLを取得
- cssセレクターを使用して、.pngの画像タグを全て取得
- 取得した画像タグそれぞれに対して、URLを生成して出力

## 上記実装の理由
- Nokogiriライブラリを使用して、指定したURLからHTMLを取得するため
- 取得したHTMLから.pngファイルのデータを取得し、URLとして出力するため

## 特にレビューして欲しい部分
nokogiriのcssセレクタでの.pngの画像タグを取得する処理。
（xpathでも取得できるみたい）

## 出力結果
取得した.pngファイルのURLを出力
![image](https://github.com/user-attachments/assets/15d0fbcd-c89a-4da2-bdf2-859071eb8e27)

## その他
外部のAPIを使用しているため、ラッパーを作成した方がいいと思った。