### PR TITLE
指定したURLからHTML情報を取得し、XPathを使用して特定の画像データを取得

### DIFF
--- a/problem08.rb
+++ b/problem08.rb
@@ -1,0 +1,15 @@
+require "nokogiri"
+require "open-uri"
+require "uri"
+
+# 画像URLを取得するwebページのURLを定義
+base_url = "https://www.kurobe-dam.com/"
+
+# Nokogiriを使って指定したURLのHTMLを取得し、パースした結果をdocに格納
+doc = Nokogiri::HTML(URI.open(base_url))
+
+# XPathを使用して取得する画像を指定
+img = doc.xpath("//img[@src='/img/img_sightseeing.jpg']")
+
+# 取得した画像タグのsrcを結像して出力
+puts URI.join(base_url, img[0]['src'])


### PR DESCRIPTION
## イシュー番号
- open #15

## 関連ドキュメント
[github nokogiri](https://github.com/sparklemotion/nokogiri)
[nokogiri 公式ドキュメント](https://nokogiri.org/index.html)
[RubyDoc URIモジュール](https://docs.ruby-lang.org/ja/latest/class/URI.html#S_JOIN)

## 実装内容
- webページのURLを定義
- Nokogiriを使用して、指定したURLのHTMLを取得
- XPathを使用して、取得する画像の指定
- URLを結合して出力

## 上記実装の理由
- Nokogiriライブラリを使用して、指定したURLからHTMLを取得するため
- 取得したHTMLからXPathで画像データを取得するため

## 特にレビューして欲しい部分
XPathの記法について確認してほしい

## 出力結果
取得したファイルのURLを出力
![image](https://github.com/user-attachments/assets/6f39fd50-e08e-4ed6-a312-fa547f2e05d1)

## その他